### PR TITLE
Add support for iter with optional attributes

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -6,9 +6,7 @@ package objstore
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -113,10 +111,8 @@ func (i *InMemBucket) SupportedIterOptions() []IterOptionType {
 }
 
 func (b *InMemBucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs IterObjectAttributes) error, options ...IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", ErrOptionNotSupported, opt.Type)
-		}
+	if err := ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	return b.Iter(ctx, dir, func(name string) error {

--- a/objstore.go
+++ b/objstore.go
@@ -6,11 +6,13 @@ package objstore
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -142,7 +144,7 @@ func WithRecursiveIter() IterOption {
 // WithUpdatedAt is an option that can be applied to Iter() to
 // include the last modified time in the attributes.
 // NB: Prefixes may not report last modified time.
-// This option is currently supported for the GCS and Filesystem providers.
+// This option is currently supported for the azure, aws, bos, gcs and filesystem providers.
 func WithUpdatedAt() IterOption {
 	return IterOption{
 		Type: UpdatedAt,
@@ -156,6 +158,16 @@ func WithUpdatedAt() IterOption {
 type IterParams struct {
 	Recursive    bool
 	LastModified bool
+}
+
+func ValidateIterOptions(supportedOptions []IterOptionType, options ...IterOption) error {
+	for _, opt := range options {
+		if !slices.Contains(supportedOptions, opt.Type) {
+			return fmt.Errorf("%w: %v", ErrOptionNotSupported, opt.Type)
+		}
+	}
+
+	return nil
 }
 
 func ApplyIterOptions(options ...IterOption) IterParams {

--- a/prefixed_bucket.go
+++ b/prefixed_bucket.go
@@ -46,12 +46,25 @@ func (p *PrefixedBucket) Close() error {
 // Iter calls f for each entry in the given directory (not recursive.). The argument to f is the full
 // object name including the prefix of the inspected directory.
 // Entries are passed to function in sorted order.
-func (p *PrefixedBucket) Iter(ctx context.Context, dir string, f func(name string, attrs ObjectAttributes) error, options ...IterOption) error {
+func (p *PrefixedBucket) Iter(ctx context.Context, dir string, f func(string) error, options ...IterOption) error {
 	pdir := withPrefix(p.prefix, dir)
 
-	return p.bkt.Iter(ctx, pdir, func(s string, _ ObjectAttributes) error {
-		return f(strings.TrimPrefix(s, p.prefix+DirDelim), EmptyObjectAttributes)
+	return p.bkt.Iter(ctx, pdir, func(s string) error {
+		return f(strings.TrimPrefix(s, p.prefix+DirDelim))
 	}, options...)
+}
+
+func (p *PrefixedBucket) IterWithAttributes(ctx context.Context, dir string, f func(IterObjectAttributes) error, options ...IterOption) error {
+	pdir := withPrefix(p.prefix, dir)
+
+	return p.bkt.IterWithAttributes(ctx, pdir, func(attrs IterObjectAttributes) error {
+		attrs.Name = strings.TrimPrefix(attrs.Name, p.prefix+DirDelim)
+		return f(attrs)
+	}, options...)
+}
+
+func (p *PrefixedBucket) SupportedIterOptions() []IterOptionType {
+	return p.SupportedIterOptions()
 }
 
 // Get returns a reader for the given object name.

--- a/prefixed_bucket_test.go
+++ b/prefixed_bucket_test.go
@@ -71,17 +71,17 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 
 	testutil.Ok(t, bkt.Upload(context.Background(), strings.Trim(prefix, "/")+"/dir/file1.jpg", strings.NewReader("test-data1")))
 	seen := []string{}
-	testutil.Ok(t, pBkt.Iter(context.Background(), "", func(fn string, _ ObjectAttributes) error {
+	testutil.Ok(t, pBkt.Iter(context.Background(), "", func(fn string) error {
 		seen = append(seen, fn)
 		return nil
-	}, WithRecursiveIter))
+	}, WithRecursiveIter()))
 	expected := []string{"dir/file1.jpg", "file1.jpg"}
 	sort.Strings(expected)
 	sort.Strings(seen)
 	testutil.Equals(t, expected, seen)
 
 	seen = []string{}
-	testutil.Ok(t, pBkt.Iter(context.Background(), "", func(fn string, _ ObjectAttributes) error {
+	testutil.Ok(t, pBkt.Iter(context.Background(), "", func(fn string) error {
 		seen = append(seen, fn)
 		return nil
 	}))

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -5,10 +5,8 @@ package azure
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -187,10 +185,8 @@ func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	prefix := dir

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -5,8 +5,10 @@ package azure
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -180,9 +182,17 @@ func NewBucketWithConfig(logger log.Logger, conf Config, component string) (*Buc
 	return bkt, nil
 }
 
-// Iter calls f for each entry in the given directory. The argument to f is the full
-// object name including the prefix of the inspected directory.
-func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, _ objstore.ObjectAttributes) error, options ...objstore.IterOption) error {
+func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+}
+
+func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
+	for _, opt := range options {
+		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
+			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
+		}
+	}
+
 	prefix := dir
 	if prefix != "" && !strings.HasSuffix(prefix, DirDelim) {
 		prefix += DirDelim
@@ -198,7 +208,13 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, _ obj
 				return err
 			}
 			for _, blob := range resp.Segment.BlobItems {
-				if err := f(*blob.Name, objstore.EmptyObjectAttributes); err != nil {
+				attrs := objstore.IterObjectAttributes{
+					Name: *blob.Name,
+				}
+				if params.LastModified {
+					attrs.SetLastModified(*blob.Properties.LastModified)
+				}
+				if err := f(attrs); err != nil {
 					return err
 				}
 			}
@@ -214,17 +230,40 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, _ obj
 			return err
 		}
 		for _, blobItem := range resp.Segment.BlobItems {
-			if err := f(*blobItem.Name, objstore.EmptyObjectAttributes); err != nil {
+			attrs := objstore.IterObjectAttributes{
+				Name: *blobItem.Name,
+			}
+			if params.LastModified {
+				attrs.SetLastModified(*blobItem.Properties.LastModified)
+			}
+			if err := f(attrs); err != nil {
 				return err
 			}
 		}
 		for _, blobPrefix := range resp.Segment.BlobPrefixes {
-			if err := f(*blobPrefix.Name, objstore.EmptyObjectAttributes); err != nil {
+			if err := f(objstore.IterObjectAttributes{Name: *blobPrefix.Name}); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+// Iter calls f for each entry in the given directory. The argument to f is the full
+// object name including the prefix of the inspected directory.
+func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
+	// Only include recursive option since attributes are not used in this method.
+	var filteredOpts []objstore.IterOption
+	for _, opt := range opts {
+		if opt.Type == objstore.Recursive {
+			filteredOpts = append(filteredOpts, opt)
+			break
+		}
+	}
+
+	return b.IterWithAttributes(ctx, dir, func(attrs objstore.IterObjectAttributes) error {
+		return f(attrs.Name)
+	}, filteredOpts...)
 }
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.

--- a/providers/bos/bos.go
+++ b/providers/bos/bos.go
@@ -11,7 +11,6 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -181,10 +180,8 @@ func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	if dir != "" {

--- a/providers/bos/bos.go
+++ b/providers/bos/bos.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -175,16 +176,25 @@ func (b *Bucket) Upload(_ context.Context, name string, r io.Reader) error {
 	return nil
 }
 
-// Iter calls f for each entry in the given directory (not recursive). The argument to f is the full
-// object name including the prefix of the inspected directory.
-func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, _ objstore.ObjectAttributes) error, opt ...objstore.IterOption) error {
+func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+}
+
+func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
+	for _, opt := range options {
+		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
+			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
+		}
+	}
+
 	if dir != "" {
 		dir = strings.TrimSuffix(dir, objstore.DirDelim) + objstore.DirDelim
 	}
 
 	delimiter := objstore.DirDelim
 
-	if objstore.ApplyIterOptions(opt...).Recursive {
+	params := objstore.ApplyIterOptions(options...)
+	if params.Recursive {
 		delimiter = ""
 	}
 
@@ -206,13 +216,25 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, _ obj
 
 		marker = objects.NextMarker
 		for _, object := range objects.Contents {
-			if err := f(object.Key, objstore.EmptyObjectAttributes); err != nil {
+			attrs := objstore.IterObjectAttributes{
+				Name: object.Key,
+			}
+
+			if params.LastModified && object.LastModified != "" {
+				lastModified, err := time.Parse(time.RFC1123, object.LastModified)
+				if err != nil {
+					return fmt.Errorf("iter: get last modified: %w", err)
+				}
+				attrs.SetLastModified(lastModified)
+			}
+
+			if err := f(attrs); err != nil {
 				return err
 			}
 		}
 
 		for _, object := range objects.CommonPrefixes {
-			if err := f(object.Prefix, objstore.EmptyObjectAttributes); err != nil {
+			if err := f(objstore.IterObjectAttributes{Name: object.Prefix}); err != nil {
 				return err
 			}
 		}
@@ -221,6 +243,23 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, _ obj
 		}
 	}
 	return nil
+}
+
+// Iter calls f for each entry in the given directory. The argument to f is the full
+// object name including the prefix of the inspected directory.
+func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
+	// Only include recursive option since attributes are not used in this method.
+	var filteredOpts []objstore.IterOption
+	for _, opt := range opts {
+		if opt.Type == objstore.Recursive {
+			filteredOpts = append(filteredOpts, opt)
+			break
+		}
+	}
+
+	return b.IterWithAttributes(ctx, dir, func(attrs objstore.IterObjectAttributes) error {
+		return f(attrs.Name)
+	}, filteredOpts...)
 }
 
 // Get returns a reader for the given object name.
@@ -347,7 +386,7 @@ func NewTestBucket(t testing.TB) (objstore.Bucket, func(), error) {
 			return nil, nil, err
 		}
 
-		if err := b.Iter(context.Background(), "", func(f string, _ objstore.ObjectAttributes) error {
+		if err := b.Iter(context.Background(), "", func(f string) error {
 			return errors.Errorf("bucket %s is not empty", c.Bucket)
 		}); err != nil {
 			return nil, nil, errors.Wrapf(err, "checking bucket %s", c.Bucket)

--- a/providers/cos/cos.go
+++ b/providers/cos/cos.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -295,10 +294,8 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	return b.Iter(ctx, dir, func(name string) error {

--- a/providers/filesystem/filesystem.go
+++ b/providers/filesystem/filesystem.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"github.com/efficientgo/core/errcapture"
 	"github.com/pkg/errors"
@@ -60,10 +59,8 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 		return ctx.Err()
 	}
 
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	params := objstore.ApplyIterOptions(options...)

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"runtime"
-	"slices"
 	"strings"
 	"testing"
 
@@ -96,10 +95,8 @@ func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	// Ensure the object name actually ends with a dir suffix. Otherwise we'll just iterate the

--- a/providers/obs/obs.go
+++ b/providers/obs/obs.go
@@ -5,11 +5,9 @@ package obs
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"math"
 	"os"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -277,10 +275,8 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	return b.Iter(ctx, dir, func(name string) error {

--- a/providers/obs/obs.go
+++ b/providers/obs/obs.go
@@ -5,9 +5,11 @@ package obs
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -232,8 +234,12 @@ func (b *Bucket) multipartUpload(size int64, key, uploadId string, body io.Reade
 
 func (b *Bucket) Close() error { return nil }
 
+func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
+	return []objstore.IterOptionType{objstore.Recursive}
+}
+
 // Iter calls f for each entry in the given directory (not recursive.)
-func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, _ objstore.ObjectAttributes) error, options ...objstore.IterOption) error {
+func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) error {
 	if dir != "" {
 		dir = strings.TrimSuffix(dir, DirDelim) + DirDelim
 	}
@@ -251,12 +257,12 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, _ obj
 			return errors.Wrap(err, "failed to list object")
 		}
 		for _, content := range output.Contents {
-			if err := f(content.Key, objstore.EmptyObjectAttributes); err != nil {
+			if err := f(content.Key); err != nil {
 				return errors.Wrapf(err, "failed to call iter function for object %s", content.Key)
 			}
 		}
 		for _, topDir := range output.CommonPrefixes {
-			if err := f(topDir, objstore.EmptyObjectAttributes); err != nil {
+			if err := f(topDir); err != nil {
 				return errors.Wrapf(err, "failed to call iter function for top dir object %s", topDir)
 			}
 		}
@@ -268,6 +274,18 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, _ obj
 		input.Marker = output.NextMarker
 	}
 	return nil
+}
+
+func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
+	for _, opt := range options {
+		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
+			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
+		}
+	}
+
+	return b.Iter(ctx, dir, func(name string) error {
+		return f(objstore.IterObjectAttributes{Name: name})
+	}, options...)
 }
 
 // Get returns a reader for the given object name.
@@ -376,7 +394,7 @@ func NewTestBucketFromConfig(t testing.TB, c Config, reuseBucket bool, location 
 
 	bktToCreate := c.Bucket
 	if c.Bucket != "" && reuseBucket {
-		if err := b.Iter(ctx, "", func(f string, _ objstore.ObjectAttributes) error {
+		if err := b.Iter(ctx, "", func(_ string) error {
 			return errors.Errorf("bucket %s is not empty", c.Bucket)
 		}); err != nil {
 			return nil, nil, err

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -133,10 +132,8 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	return b.Iter(ctx, dir, func(name string) error {

--- a/providers/oss/oss.go
+++ b/providers/oss/oss.go
@@ -11,7 +11,6 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -251,10 +250,8 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	return b.Iter(ctx, dir, func(name string) error {

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -385,18 +386,28 @@ func ValidateForTests(conf Config) error {
 	return nil
 }
 
-// Iter calls f for each entry in the given directory. The argument to f is the full
-// object name including the prefix of the inspected directory.
-func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, attrs objstore.ObjectAttributes) error, options ...objstore.IterOption) error {
+func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+}
+
+func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
+	for _, opt := range options {
+		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
+			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
+		}
+	}
+
 	// Ensure the object name actually ends with a dir suffix. Otherwise we'll just iterate the
 	// object itself as one prefix item.
 	if dir != "" {
 		dir = strings.TrimSuffix(dir, DirDelim) + DirDelim
 	}
 
+	appliedOpts := objstore.ApplyIterOptions(options...)
+
 	opts := minio.ListObjectsOptions{
 		Prefix:    dir,
-		Recursive: objstore.ApplyIterOptions(options...).Recursive,
+		Recursive: appliedOpts.Recursive,
 		UseV1:     b.listObjectsV1,
 	}
 
@@ -413,12 +424,35 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(name string, attrs
 		if object.Key == dir {
 			continue
 		}
-		if err := f(object.Key, objstore.EmptyObjectAttributes); err != nil {
+
+		attr := objstore.IterObjectAttributes{
+			Name: object.Key,
+		}
+		if appliedOpts.LastModified {
+			attr.SetLastModified(object.LastModified)
+		}
+
+		if err := f(attr); err != nil {
 			return err
 		}
 	}
 
 	return ctx.Err()
+}
+
+func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
+	// Only include recursive option since attributes are not used in this method.
+	var filteredOpts []objstore.IterOption
+	for _, opt := range opts {
+		if opt.Type == objstore.Recursive {
+			filteredOpts = append(filteredOpts, opt)
+			break
+		}
+	}
+
+	return b.IterWithAttributes(ctx, dir, func(attrs objstore.IterObjectAttributes) error {
+		return f(attrs.Name)
+	}, filteredOpts...)
 }
 
 func (b *Bucket) getRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
@@ -609,7 +643,7 @@ func NewTestBucketFromConfig(t testing.TB, location string, c Config, reuseBucke
 
 	bktToCreate := c.Bucket
 	if c.Bucket != "" && reuseBucket {
-		if err := b.Iter(ctx, "", func(f string, _ objstore.ObjectAttributes) error {
+		if err := b.Iter(ctx, "", func(string) error {
 			return errors.Errorf("bucket %s is not empty", c.Bucket)
 		}); err != nil {
 			return nil, nil, errors.Wrapf(err, "s3 check bucket %s", c.Bucket)

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -391,10 +390,8 @@ func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(b.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	// Ensure the object name actually ends with a dir suffix. Otherwise we'll just iterate the

--- a/providers/swift/swift.go
+++ b/providers/swift/swift.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -242,10 +241,8 @@ func (c *Container) Iter(ctx context.Context, dir string, f func(string) error, 
 }
 
 func (c *Container) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
-	for _, opt := range options {
-		if !slices.Contains(c.SupportedIterOptions(), opt.Type) {
-			return fmt.Errorf("%w: %v", objstore.ErrOptionNotSupported, opt.Type)
-		}
+	if err := objstore.ValidateIterOptions(c.SupportedIterOptions(), options...); err != nil {
+		return err
 	}
 
 	return c.Iter(ctx, dir, func(name string) error {

--- a/tracing/opentracing/opentracing.go
+++ b/tracing/opentracing/opentracing.go
@@ -44,12 +44,24 @@ func WrapWithTraces(bkt objstore.Bucket) objstore.InstrumentedBucket {
 	return TracingBucket{bkt: bkt}
 }
 
-func (t TracingBucket) Iter(ctx context.Context, dir string, f func(name string, _ objstore.ObjectAttributes) error, options ...objstore.IterOption) (err error) {
+func (t TracingBucket) Iter(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) (err error) {
 	doWithSpan(ctx, "bucket_iter", func(spanCtx context.Context, span opentracing.Span) {
 		span.LogKV("dir", dir)
 		err = t.bkt.Iter(spanCtx, dir, f, options...)
 	})
 	return
+}
+
+func (t TracingBucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) (err error) {
+	doWithSpan(ctx, "bucket_iter_with_attrs", func(spanCtx context.Context, span opentracing.Span) {
+		span.LogKV("dir", dir)
+		err = t.bkt.IterWithAttributes(spanCtx, dir, f, options...)
+	})
+	return
+}
+
+func (t TracingBucket) SupportedIterOptions() []objstore.IterOptionType {
+	return t.bkt.SupportedIterOptions()
 }
 
 func (t TracingBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
